### PR TITLE
Fix bad merge in prvSetupSocketRecvTimeout

### DIFF
--- a/FreeRTOS-Plus/Source/Application-Protocols/network_transport/tcp_sockets_wrapper/ports/cellular/tcp_sockets_wrapper.c
+++ b/FreeRTOS-Plus/Source/Application-Protocols/network_transport/tcp_sockets_wrapper/ports/cellular/tcp_sockets_wrapper.c
@@ -456,10 +456,7 @@ static BaseType_t prvSetupSocketRecvTimeout( cellularSocketWrapper_t * pCellular
     }
     else
     {
-        if( receiveTimeout >= portMAX_DELAY )
-        {
-            cellularSocketHandle = pCellularSocketContext->cellularSocketHandle;
-        }
+        cellularSocketHandle = pCellularSocketContext->cellularSocketHandle;
 
         if( receiveTimeout >= UINT32_MAX_MS_TICKS )
         {


### PR DESCRIPTION
Fix bad merge in prvSetupSocketRecvTimeout, most likely because there were merge conflicts from our changes on the fork and the upstream repo.